### PR TITLE
Add multilingual privacy statements

### DIFF
--- a/_pages/tunerforukulele/de-DE/privacy.md
+++ b/_pages/tunerforukulele/de-DE/privacy.md
@@ -8,7 +8,7 @@ title:  "Tuner for Ukulele - Datenschutzerklärung"
 ## Welche Daten gesammelt werden und warum
 Wir sammeln keine Daten durch die App.
 
-## We wir die Daten teilen, die wir sammeln
+## Wie wir die gesammelten Daten teilen
 Wir sammeln keine Daten und teilen keine Daten durch die App.
 
 ## Zugriff und Kontrolle der eigenen Benutzerdaten
@@ -18,7 +18,7 @@ Wir sammeln keine Daten.
 Wir speichern keine Daten.
 
 ## Änderungen an der Datenschutzerklärung
-Mit dem Wachstum der App, wächst auch diese Datenschutzerklärung.
+Mit dem Wachstum der App wächst auch diese Datenschutzerklärung.
 Jede Änderung wird auf dieser Seite veröffentlicht.
-Die Nutzung der App im Anschluss an diese Änderungen gilt als Akzeptanz dieser.
-Diese Seite sollte bitte regelmässig geprüft werden um Änderungen zu erkennen.
+Die Nutzung der App im Anschluss an diese Änderungen gilt als Akzeptanz der neuen Erklärung.
+Bitte prüfen Sie diese Seite regelmäßig, um Änderungen zu erkennen.

--- a/_pages/tunerforukulele/en-US/privacy.md
+++ b/_pages/tunerforukulele/en-US/privacy.md
@@ -9,16 +9,16 @@ title:  "Tuner for Ukulele - Privacy Statement"
 We do not collect any information through the app.
 
 ## How we share the information we collect
-We do not collect nor share any information through the app.
+We do not collect or share any information through the app.
 
 ## How you can access and control the information we collect
 We do not collect any information.
 
 ## How we hold your information
-We do not!
+We do not store any information.
 
 ## Changes to our Privacy Statement
-As our service grows, so will our Privacy Policy.  
-We will post changes to our Privacy Policy on this page.  
-Your use of the Services following these changes means that you accept the  
+As our service grows, so will our Privacy Policy.
+We will post changes to our Privacy Policy on this page.
+Your use of the Services following these changes means that you accept the
 revised Privacy Policy. Please check this page regularly to keep up-to-date.

--- a/_pages/tunerforukulele/es-ES/privacy.md
+++ b/_pages/tunerforukulele/es-ES/privacy.md
@@ -1,0 +1,24 @@
+---
+layout: default
+title:  "Tuner for Ukulele - Política de privacidad"
+---
+
+# Privacidad - Tuner for Ukulele
+
+## Información que recopilamos y por qué
+No recopilamos ninguna información a través de la aplicación.
+
+## Cómo compartimos la información que recopilamos
+No recopilamos ni compartimos ninguna información a través de la aplicación.
+
+## Cómo puede acceder y controlar la información que recopilamos
+No recopilamos ninguna información.
+
+## Cómo almacenamos su información
+No almacenamos ninguna información.
+
+## Cambios en nuestra política de privacidad
+A medida que nuestro servicio crezca, también lo hará nuestra política de privacidad.
+Publicaremos los cambios en esta página.
+El uso de los servicios después de estos cambios implica la aceptación de la política de privacidad revisada.
+Revise esta página regularmente para mantenerse informado.

--- a/_pages/tunerforukulele/fr-FR/privacy.md
+++ b/_pages/tunerforukulele/fr-FR/privacy.md
@@ -1,0 +1,24 @@
+---
+layout: default
+title:  "Tuner for Ukulele - Politique de confidentialité"
+---
+
+# Confidentialité - Tuner for Ukulele
+
+## Informations que nous collectons et pourquoi
+Nous ne collectons aucune information via l'application.
+
+## Comment nous partageons les informations que nous collectons
+Nous ne collectons ni ne partageons aucune information via l'application.
+
+## Comment vous pouvez accéder aux informations que nous collectons et les contrôler
+Nous ne collectons aucune information.
+
+## Comment nous conservons vos informations
+Nous ne stockons aucune information.
+
+## Modifications de notre politique de confidentialité
+Au fur et à mesure que notre service se développe, notre politique de confidentialité évoluera également.
+Nous publierons les modifications sur cette page.
+L'utilisation des services après ces modifications signifie que vous acceptez la politique de confidentialité révisée.
+Veuillez consulter cette page régulièrement pour rester informé.

--- a/_pages/tunerforukulele/it-IT/privacy.md
+++ b/_pages/tunerforukulele/it-IT/privacy.md
@@ -1,0 +1,24 @@
+---
+layout: default
+title:  "Tuner for Ukulele - Informativa sulla privacy"
+---
+
+# Privacy - Tuner for Ukulele
+
+## Informazioni che raccogliamo e perché
+Non raccogliamo alcuna informazione tramite l'app.
+
+## Come condividiamo le informazioni che raccogliamo
+Non raccogliamo né condividiamo alcuna informazione tramite l'app.
+
+## Come puoi accedere e controllare le informazioni che raccogliamo
+Non raccogliamo alcuna informazione.
+
+## Come conserviamo le tue informazioni
+Non archiviamo alcuna informazione.
+
+## Modifiche alla nostra informativa sulla privacy
+Man mano che il nostro servizio cresce, crescerà anche la nostra informativa sulla privacy.
+Pubblicheremo le modifiche su questa pagina.
+L'uso dei servizi dopo tali modifiche implica l'accettazione dell'informativa sulla privacy aggiornata.
+Controlla regolarmente questa pagina per restare aggiornato.

--- a/_pages/tunerforukulele/pt-PT/privacy.md
+++ b/_pages/tunerforukulele/pt-PT/privacy.md
@@ -1,0 +1,24 @@
+---
+layout: default
+title:  "Tuner for Ukulele - Política de privacidade"
+---
+
+# Privacidade - Tuner for Ukulele
+
+## Informações que recolhemos e porquê
+Não recolhemos quaisquer informações através da aplicação.
+
+## Como partilhamos as informações que recolhemos
+Não recolhemos nem partilhamos quaisquer informações através da aplicação.
+
+## Como pode aceder e controlar as informações que recolhemos
+Não recolhemos quaisquer informações.
+
+## Como guardamos as suas informações
+Não armazenamos quaisquer informações.
+
+## Alterações à nossa política de privacidade
+À medida que o nosso serviço cresce, também a nossa política de privacidade crescerá.
+Publicaremos as alterações nesta página.
+A utilização dos serviços após essas alterações significa que aceita a política de privacidade revista.
+Verifique esta página regularmente para se manter atualizado.


### PR DESCRIPTION
## Summary
- improve English and German privacy statements
- add privacy statements for Spanish, French, Italian, and Portuguese

## Testing
- `jekyll build` *(fails: command not found)*
- `gem install jekyll` *(fails: 403 "Forbidden" installing gem)*

------
https://chatgpt.com/codex/tasks/task_e_68c82d9292ac832086ee5eb5b3fe0c02